### PR TITLE
Minor changes to prepare for merge

### DIFF
--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -283,14 +283,14 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_hail_on]
   standard_name = nssl_hail_on
   long_name = hail activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
@@ -710,14 +710,14 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_hail_on]
   standard_name = nssl_hail_on
   long_name = hail activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -208,14 +208,14 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_invertccn]
   standard_name = nssl_invertccn
   long_name = flag to invert CCN in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -715,13 +715,11 @@
       ntrw, ntsw, ntrnc, ntsnc, ntgl, ntgnc, ntlnc, ntinc, ntccn, nn, imp_physics, imp_physics_gfdl, imp_physics_thompson,  &
       imp_physics_nssl, nssl_invertccn, nssl_ccn_on,                                                  &
       imp_physics_zhao_carr, imp_physics_zhao_carr_pdf, convert_dry_rho, dtf, save_qc, save_qi, con_pi, dtidx, dtend,&
-      index_of_process_conv_trans, gq0, clw, prsl, save_tcp, con_rd, con_eps, nwfa, spechum, ldiag3d,                &
+      index_of_process_conv_trans, gq0, clw, prsl, save_tcp, con_rd, con_eps, nssl_cccn, nwfa, spechum, ldiag3d,     &
       qdiag3d, save_lnc, save_inc, ntk, ntke, otsptflag, errmsg, errflg)
 
       use machine,               only: kind_phys
-      use module_mp_nssl_2mom,   only: qccn
       use module_mp_thompson_make_number_concentrations, only: make_IceNumber, make_DropletNumber
-
 
       implicit none
 
@@ -749,7 +747,7 @@
       real(kind=kind_phys), dimension(:,:,:), intent(inout) :: gq0
       real(kind=kind_phys), dimension(:,:,:), intent(inout) :: clw
       real(kind=kind_phys), dimension(:,:),   intent(in) :: prsl
-      real(kind=kind_phys),                   intent(in) :: con_rd, con_eps
+      real(kind=kind_phys),                   intent(in) :: con_rd, con_eps, nssl_cccn
       real(kind=kind_phys), dimension(:,:),   intent(in) :: nwfa, save_tcp
       real(kind=kind_phys), dimension(:,:),   intent(in) :: spechum
 
@@ -759,7 +757,7 @@
       ! local variables
       real(kind=kind_phys), parameter :: zero = 0.0_kind_phys, one = 1.0_kind_phys
       integer :: i,k,n,tracers,idtend
-      real(kind=kind_phys) :: liqm, icem, xccn, xcwmas, xccw, xcimas ! , qccn
+      real(kind=kind_phys) :: liqm, icem, xccn, xcwmas, xccw, xcimas, qccn
 
       real(kind=kind_phys) :: rho, orho
       real(kind=kind_phys), dimension(im,levs) :: qv_mp !< kg kg-1 (dry mixing ratio)
@@ -869,7 +867,7 @@
           if ( imp_physics == imp_physics_nssl ) then
               liqm =  con_pi/6.*1.e3*(18.e-6)**3  ! 4./3.*con_pi*1.e-12
               icem =  con_pi/6.*1.e3*(120.e-6)**3 ! 4./3.*con_pi*3.2768*1.e-14*890.
-              ! qccn = nssl_cccn/1.225
+              qccn = nssl_cccn/1.225 !1.225 is a reference air density and should match what is used in module_mp_nssl_2mom.F90 (rho00)
               do k=1,levs
                 do i=1,im
                    ! check number of available ccn
@@ -1043,4 +1041,3 @@
     end subroutine GFS_suite_interstitial_5_run
 
   end module GFS_suite_interstitial_5
-

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_suite_interstitial_rad_reset
   type = scheme
-  dependencies = machine.F,module_mp_thompson_make_number_concentrations.F90,module_mp_nssl_2mom.F90
+  dependencies = machine.F,module_mp_thompson_make_number_concentrations.F90
 
 ########################################################################
 [ccpp-arg-table]
@@ -1677,14 +1677,14 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_invertccn]
   standard_name = nssl_invertccn
   long_name = flag to invert CCN in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
@@ -1780,6 +1780,14 @@
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants
   long_name = rd/rv
   units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[nssl_cccn]
+  standard_name = nssl_ccn_concentration
+  long_name = CCN concentration
+  units = m-3
   dimensions = ()
   type = real
   kind = kind_phys

--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -1276,7 +1276,7 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in

--- a/physics/mp_nssl.F90
+++ b/physics/mp_nssl.F90
@@ -168,39 +168,39 @@ module mp_nssl
          integer,                   intent(in)    :: mpirank
          ! Hydrometeors
          logical,                   intent(in   ) :: convert_dry_rho
-         real(kind_phys),           intent(inout) :: spechum(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: cccn(:,:) ! (1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: cccna(:,:) ! (1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: qc(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: qr(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: qi(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: qs(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: qh(1:ncol,1:nlev)  ! graupel
-         real(kind_phys),           intent(inout) :: qhl(:,:) ! (1:ncol,1:nlev) ! hail
-         real(kind_phys),           intent(inout) :: ccw(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: crw(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: cci(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: csw(1:ncol,1:nlev)
-         real(kind_phys),           intent(inout) :: chw(1:ncol,1:nlev) ! graupel number
-         real(kind_phys),           intent(inout) :: chl(:,:) ! (1:ncol,1:nlev) ! hail number
-         real(kind_phys),           intent(inout) :: vh(1:ncol,1:nlev)  ! graupel volume
-         real(kind_phys),           intent(inout) :: vhl(:,:) ! (1:ncol,1:nlev) ! hail volume
+         real(kind_phys),           intent(inout) :: spechum(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: cccn(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: cccna(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: qc (:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: qr (:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: qi (:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: qs (:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: qh (:,:) !(1:ncol,1:nlev) graupel
+         real(kind_phys),           intent(inout) :: qhl(:,:) !(1:ncol,1:nlev) hail
+         real(kind_phys),           intent(inout) :: ccw(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: crw(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: cci(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: csw(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: chw(:,:) !(1:ncol,1:nlev) graupel number 
+         real(kind_phys),           intent(inout) :: chl(:,:) !(1:ncol,1:nlev) hail number
+         real(kind_phys),           intent(inout) :: vh (:,:) !(1:ncol,1:nlev) graupel volume 
+         real(kind_phys),           intent(inout) :: vhl(:,:) !(1:ncol,1:nlev) hail volume
          ! State variables and timestep information
-         real(kind_phys),           intent(inout) :: tgrs(1:ncol,1:nlev)
-         real(kind_phys),           intent(in   ) :: prsl(1:ncol,1:nlev)
-         real(kind_phys),           intent(in   ) :: prslk(1:ncol,1:nlev)
-         real(kind_phys),           intent(in   ) :: phii(1:ncol,1:nlev+1)
-         real(kind_phys),           intent(in   ) :: omega(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: tgrs (:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(in   ) :: prsl (:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(in   ) :: prslk(:,:) !(1:ncol,1:nlev)
+         real(kind_phys),           intent(in   ) :: phii (:,:) !(1:ncol,1:nlev+1)
+         real(kind_phys),           intent(in   ) :: omega(:,:) !(1:ncol,1:nlev)
          real(kind_phys),           intent(in   ) :: dtp
          ! Precip/rain/snow/graupel fall amounts and fraction of frozen precip
-         real(kind_phys),           intent(  out) :: prcp(1:ncol)
-         real(kind_phys),           intent(  out) :: rain(1:ncol)
-         real(kind_phys),           intent(  out) :: graupel(1:ncol)
-         real(kind_phys),           intent(  out) :: ice(1:ncol)
-         real(kind_phys),           intent(  out) :: snow(1:ncol)
-         real(kind_phys),           intent(  out) :: sr(1:ncol)
+         real(kind_phys),           intent(  out) :: prcp   (:) !(1:ncol)
+         real(kind_phys),           intent(  out) :: rain   (:) !(1:ncol)
+         real(kind_phys),           intent(  out) :: graupel(:) !(1:ncol)
+         real(kind_phys),           intent(  out) :: ice    (:) !(1:ncol)
+         real(kind_phys),           intent(  out) :: snow   (:) !(1:ncol)
+         real(kind_phys),           intent(  out) :: sr     (:) !(1:ncol)
          ! Radar reflectivity
-         real(kind_phys),           intent(inout) :: refl_10cm(1:ncol,1:nlev)
+         real(kind_phys),           intent(inout) :: refl_10cm(:,:) !(1:ncol,1:nlev)
          logical,                   intent(in   ) :: do_radar_ref, first_time_step
          ! Cloud effective radii
          real(kind_phys),  intent(inout) :: re_cloud(:,:) ! (1:ncol,1:nlev)

--- a/physics/mp_nssl.meta
+++ b/physics/mp_nssl.meta
@@ -168,21 +168,21 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_hail_on]
   standard_name = nssl_hail_on
   long_name = hail activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_invertccn]
   standard_name = nssl_invertccn
   long_name = flag to invert CCN in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
@@ -565,21 +565,21 @@
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_hail_on]
   standard_name = nssl_hail_on
   long_name = hail activation flag in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in
 [nssl_invertccn]
   standard_name = nssl_invertccn
   long_name = flag to invert CCN in NSSL micro
-  units = none
+  units = flag
   dimensions = ()
   type = logical
   intent = in


### PR DESCRIPTION
This PR has the following changes:

- change units of flags from none to flag to adhere to CCPP metadata guidelines: https://github.com/ESCOMP/CCPPStandardNames/blob/main/StandardNamesRules.rst
- remove dependency on module_mp_nssl_2mom in GFS_suite_interstitial -- passing in nssl_cccn and dividing by the reference density is preferable to always have to compile NSSL MP, even when not in use
- use assumed-shape arrays in mp_nssl.F90 to trigger array bounds checking and conform with CCPP guidelines